### PR TITLE
Mark RGB as repr(C)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ mod dim_parser;
 
 /// The decoded R, G, and B value of a pixel. You typically get these from the data field on an
 /// [`Image`].
+#[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RGB {
     /// The red channel.


### PR DESCRIPTION
Thanks for writing this, it's much faster than `image2`'s HDR parsing!

Since there is no guarantee about padding using Rust's default struct packing (https://doc.rust-lang.org/reference/type-layout.html#the-default-representation), I believe the pixel struct `RGB` should be marked as `#[repr(C)]`. With the C ABI layout, there is guaranteed to be no padding in the struct. This allows it to be used in FFI e.g. with something like OpenGL `glBindBuffer`. Currently, Rust does not add any padding, but better safe than sorry.